### PR TITLE
feat: htmx 4 support — HTMXv4RenderTarget + html-template example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 | Directory | What it shows |
 |---|---|
 | [`simple/`](./simple) | Minimal struct-routed pages with templ — no HTMX, no DI |
+| [`html-template/`](./html-template) | Standard library `html/template` with htmx 4 partial swaps, using `htmltemplate.Funcs` for `urlFor` inside templates |
 | [`htmx/`](./htmx) | HTMX navigation with `hx-target` + a small `urlFor` wrapper |
 | [`htmx-render-target/`](./htmx-render-target) | Standalone-function components shared across pages, driven by `RenderTarget` for per-component data loading |
 | [`todo/`](./todo) | Full TODO app: form actions via `ServeHTTP` returning `RenderComponent(...)` to re-render a sibling component |
@@ -27,4 +28,4 @@ templ generate --watch --proxy="http://localhost:8080" --cmd="go run ."
 
 You'll need:
 - Go 1.24+
-- `templ` CLI: `go install github.com/a-h/templ/cmd/templ@latest`
+- `templ` CLI: `go install github.com/a-h/templ/cmd/templ@latest` (not required for `html-template/`, which uses only the standard library)

--- a/examples/html-template/go.mod
+++ b/examples/html-template/go.mod
@@ -1,0 +1,9 @@
+module github.com/jackielii/structpages/examples/html-template
+
+go 1.24.3
+
+require github.com/jackielii/structpages v0.0.0-00010101000000-000000000000
+
+require github.com/jackielii/ctxkey v1.0.1 // indirect
+
+replace github.com/jackielii/structpages => ../..

--- a/examples/html-template/go.sum
+++ b/examples/html-template/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/jackielii/ctxkey v1.0.1 h1:CcgbR+fQbrzZJWxI/7Ec4EhzUbmTU1sfI1gV7MAgjIg=
+github.com/jackielii/ctxkey v1.0.1/go.mod h1:fo4HOwrvSnc3n8o5qZ5L+FVcSyQn+d67CCnlEbH24uc=

--- a/examples/html-template/main.go
+++ b/examples/html-template/main.go
@@ -1,0 +1,101 @@
+// Demonstrates structpages with the standard library's html/template.
+//
+// structpages is render-engine agnostic: a Page() method can return any value
+// with a Render(ctx context.Context, w io.Writer) error method. Here, the
+// `tpl` type wraps an html/template set; structpages/htmltemplate.Funcs
+// supplies the urlFor / idFor / idTarget bindings inside templates.
+package main
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"html/template"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/jackielii/structpages"
+	"github.com/jackielii/structpages/htmltemplate"
+)
+
+//go:embed templates/*.html
+var tmplFS embed.FS
+
+// pageTmpls holds one fully-parsed (layout + body) template set per page.
+// Parsing per page avoids the html/template name collision that happens when
+// every page defines a "body" template inside one shared set.
+var pageTmpls = map[string]*template.Template{
+	"index":   parsePage("index.html"),
+	"product": parsePage("product.html"),
+	"team":    parsePage("team.html"),
+	"contact": parsePage("contact.html"),
+}
+
+func parsePage(file string) *template.Template {
+	// Funcs(nil) registers placeholder names so the parser accepts urlFor/idFor
+	// references; we rebind with a real context inside Render.
+	t := template.New("").Funcs(htmltemplate.Funcs(nil))
+	return template.Must(t.ParseFS(tmplFS, "templates/layout.html", "templates/"+file))
+}
+
+// tpl is a renderable component backed by one of the parsed page templates.
+// `entry` selects which named template to execute (e.g. "layout" for the full
+// page, "body" for the HTMX partial swap).
+type tpl struct {
+	page  string
+	entry string
+	data  any
+}
+
+func (p tpl) Render(ctx context.Context, w io.Writer) error {
+	t, ok := pageTmpls[p.page]
+	if !ok {
+		return fmt.Errorf("unknown template %q", p.page)
+	}
+	clone, err := t.Clone()
+	if err != nil {
+		return err
+	}
+	clone.Funcs(htmltemplate.Funcs(ctx))
+	return clone.ExecuteTemplate(w, p.entry, p.data)
+}
+
+func full(name string) tpl    { return tpl{page: name, entry: "layout"} }
+func partial(name string) tpl { return tpl{page: name, entry: "body"} }
+
+type index struct {
+	product `route:"/product Product"`
+	team    `route:"/team Team"`
+	contact `route:"/contact Contact"`
+}
+
+func (index) Page() tpl { return full("index") }
+func (index) Main() tpl { return partial("index") }
+
+type product struct{}
+
+func (product) Page() tpl { return full("product") }
+func (product) Main() tpl { return partial("product") }
+
+type team struct{}
+
+func (team) Page() tpl { return full("team") }
+func (team) Main() tpl { return partial("team") }
+
+type contact struct{}
+
+func (contact) Page() tpl { return full("contact") }
+func (contact) Main() tpl { return partial("contact") }
+
+func main() {
+	mux := http.NewServeMux()
+	if _, err := structpages.Mount(mux, index{}, "/", "Index",
+		// htmx 4 sends HX-Target as "<tag>#<id>" instead of the bare id.
+		structpages.WithTargetSelector(structpages.HTMXv4RenderTarget),
+	); err != nil {
+		log.Fatalf("mount: %v", err)
+	}
+	log.Println("Listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}

--- a/examples/html-template/templates/contact.html
+++ b/examples/html-template/templates/contact.html
@@ -1,0 +1,4 @@
+{{ define "body" -}}
+<h1>Contact Page</h1>
+<p>This is the contact page.</p>
+{{- end }}

--- a/examples/html-template/templates/index.html
+++ b/examples/html-template/templates/index.html
@@ -1,0 +1,4 @@
+{{ define "body" -}}
+<h1>Welcome to the Index Page</h1>
+<p>Navigate to the product, team, or contact pages using the links above.</p>
+{{- end }}

--- a/examples/html-template/templates/layout.html
+++ b/examples/html-template/templates/layout.html
@@ -11,14 +11,14 @@
   <header class="navbar">
     <nav>
       <ul role="list">
-        <li><a hx-get="{{ urlFor "index"   }}" hx-target="#main" hx-push-url="true">Home</a></li>
-        <li><a hx-get="{{ urlFor "product" }}" hx-target="#main" hx-push-url="true">Product</a></li>
-        <li><a hx-get="{{ urlFor "team"    }}" hx-target="#main" hx-push-url="true">Team</a></li>
-        <li><a hx-get="{{ urlFor "contact" }}" hx-target="#main" hx-push-url="true">Contact</a></li>
+        <li><a hx-get="{{ urlFor "index"   }}" hx-target="main" hx-push-url="true">Home</a></li>
+        <li><a hx-get="{{ urlFor "product" }}" hx-target="main" hx-push-url="true">Product</a></li>
+        <li><a hx-get="{{ urlFor "team"    }}" hx-target="main" hx-push-url="true">Team</a></li>
+        <li><a hx-get="{{ urlFor "contact" }}" hx-target="main" hx-push-url="true">Contact</a></li>
       </ul>
     </nav>
   </header>
-  <main id="main">
+  <main>
     {{ template "body" . }}
   </main>
 </body>

--- a/examples/html-template/templates/layout.html
+++ b/examples/html-template/templates/layout.html
@@ -1,0 +1,26 @@
+{{ define "layout" -}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="https://unpkg.com/missing.css@1.1.3">
+  <script src="https://cdn.jsdelivr.net/npm/htmx.org@4.0.0-beta2/dist/htmx.min.js"></script>  
+  <title>html/template Example</title>
+</head>
+<body>
+  <header class="navbar">
+    <nav>
+      <ul role="list">
+        <li><a hx-get="{{ urlFor "index"   }}" hx-target="#main" hx-push-url="true">Home</a></li>
+        <li><a hx-get="{{ urlFor "product" }}" hx-target="#main" hx-push-url="true">Product</a></li>
+        <li><a hx-get="{{ urlFor "team"    }}" hx-target="#main" hx-push-url="true">Team</a></li>
+        <li><a hx-get="{{ urlFor "contact" }}" hx-target="#main" hx-push-url="true">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main">
+    {{ template "body" . }}
+  </main>
+</body>
+</html>
+{{- end }}

--- a/examples/html-template/templates/product.html
+++ b/examples/html-template/templates/product.html
@@ -1,0 +1,4 @@
+{{ define "body" -}}
+<h1>Product Page</h1>
+<p>This is the product page.</p>
+{{- end }}

--- a/examples/html-template/templates/team.html
+++ b/examples/html-template/templates/team.html
@@ -1,0 +1,4 @@
+{{ define "body" -}}
+<h1>Team Page</h1>
+<p>This is the team page.</p>
+{{- end }}

--- a/htmltemplate/htmltemplate.go
+++ b/htmltemplate/htmltemplate.go
@@ -1,0 +1,65 @@
+// Package htmltemplate provides helpers for using html/template with structpages.
+//
+// structpages itself is render-engine agnostic: any value with a
+// Render(ctx context.Context, w io.Writer) error method can be returned from
+// a Page() method. This package only adds the small piece of glue that is
+// awkward to write by hand — a [template.FuncMap] that lets templates call
+// urlFor / idFor / idTarget with the request context.
+//
+// Typical usage:
+//
+//	// At parse time, register placeholder funcs so the parser knows the names:
+//	var tmpl = template.Must(template.New("").
+//	    Funcs(htmltemplate.Funcs(nil)).
+//	    ParseFS(fs, "*.html"))
+//
+//	// At render time, clone and rebind with the request context:
+//	t, _ := tmpl.Clone()
+//	t.Funcs(htmltemplate.Funcs(ctx))
+//	_ = t.ExecuteTemplate(w, "layout", data)
+//
+// In templates:
+//
+//	<a href="{{ urlFor "ProductPage" }}">Product</a>
+//	<a href="{{ urlFor "UserPage" "id" 42 }}">User 42</a>
+//	<button hx-target="{{ idTarget "Dashboard.UserList" }}">Refresh</button>
+package htmltemplate
+
+import (
+	"context"
+	"html/template"
+
+	"github.com/jackielii/structpages"
+)
+
+// Funcs returns a [template.FuncMap] that binds urlFor, idFor, and idTarget
+// to ctx. Page references use the [structpages.Ref] convention: page name
+// (e.g. "ProductPage") or route path (e.g. "/products"); for ids, the dotted
+// "PageName.MethodName" form is also supported.
+//
+// Pass a nil ctx at parse time to register placeholder funcs, then call Funcs
+// again with the request context before [template.Template.Execute]. Calls
+// made with a nil ctx return empty strings rather than panicking, so a
+// forgotten rebind surfaces as missing URLs rather than a 500.
+func Funcs(ctx context.Context) template.FuncMap {
+	return template.FuncMap{
+		"urlFor": func(name string, args ...any) (string, error) {
+			if ctx == nil {
+				return "", nil
+			}
+			return structpages.URLFor(ctx, structpages.Ref(name), args...)
+		},
+		"idFor": func(name string) (string, error) {
+			if ctx == nil {
+				return "", nil
+			}
+			return structpages.ID(ctx, structpages.Ref(name))
+		},
+		"idTarget": func(name string) (string, error) {
+			if ctx == nil {
+				return "", nil
+			}
+			return structpages.IDTarget(ctx, structpages.Ref(name))
+		},
+	}
+}

--- a/htmltemplate/htmltemplate_test.go
+++ b/htmltemplate/htmltemplate_test.go
@@ -1,0 +1,73 @@
+package htmltemplate_test
+
+import (
+	"bytes"
+	"context"
+	"html/template"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jackielii/structpages"
+	"github.com/jackielii/structpages/htmltemplate"
+)
+
+var indexTmpl = template.Must(template.New("t").
+	Funcs(htmltemplate.Funcs(nil)).
+	Parse(`{{ urlFor "Product" }}|{{ urlFor "User" "id" 42 }}|{{ urlFor "/products" }}`))
+
+type tpl struct{ name string }
+
+func (p tpl) Render(ctx context.Context, w io.Writer) error {
+	clone, err := indexTmpl.Clone()
+	if err != nil {
+		return err
+	}
+	clone.Funcs(htmltemplate.Funcs(ctx))
+	return clone.ExecuteTemplate(w, p.name, nil)
+}
+
+type productPage struct{}
+type userPage struct{}
+
+type indexPage struct {
+	Product productPage `route:"/products Product"`
+	User    userPage    `route:"/users/{id} User"`
+}
+
+func (indexPage) Page() tpl { return tpl{name: "t"} }
+
+func TestFuncs_NilCtx_ReturnsEmpty(t *testing.T) {
+	tmpl := template.Must(template.New("nilctx").
+		Funcs(htmltemplate.Funcs(nil)).
+		Parse(`url={{ urlFor "X" }} id={{ idFor "Y" }} target={{ idTarget "Z" }}`))
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, nil); err != nil {
+		t.Fatalf("execute with nil ctx: %v", err)
+	}
+	if !strings.Contains(buf.String(), "url= id= target=") {
+		t.Errorf("expected empty values, got %q", buf.String())
+	}
+}
+
+func TestFuncs_BoundCtx_ResolvesURLs(t *testing.T) {
+	mux := http.NewServeMux()
+	if _, err := structpages.Mount(mux, indexPage{}, "/", "Index",
+		structpages.WithWarnEmptyRoute(func(*structpages.PageNode) {})); err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d, body %s", rr.Code, rr.Body.String())
+	}
+	want := "/products|/users/42|/products"
+	if got := strings.TrimSpace(rr.Body.String()); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/htmx.go
+++ b/htmx.go
@@ -15,6 +15,9 @@ import (
 //   - HX-Target: "user-stats-widget" (no method match) -> returns functionRenderTarget for lazy evaluation
 //   - No HX-Target or non-HTMX request -> returns methodRenderTarget for Page() method
 //
+// This selector works with htmx 1.x and 2.x, where HX-Target carries the bare
+// element id. For htmx 4, use [HTMXv4RenderTarget] instead.
+//
 // This is the default TargetSelector for StructPages, making IDFor work
 // seamlessly with HTMX out of the box.
 func HTMXRenderTarget(r *http.Request, pn *PageNode) (RenderTarget, error) {
@@ -39,6 +42,62 @@ func HTMXRenderTarget(r *http.Request, pn *PageNode) (RenderTarget, error) {
 	// forcing Props to use RenderComponent
 	pageMethod := pn.Components["Page"]
 	return newMethodRenderTarget("Page", &pageMethod), nil
+}
+
+// HTMXv4RenderTarget is the htmx 4 variant of [HTMXRenderTarget].
+//
+// htmx 4 reshaped two request headers we care about:
+//
+//   - HX-Target now carries "<tag>#<id>" (or just "<tag>" for unidentified
+//     elements) instead of a bare id.
+//   - HX-Request-Type was added: "full" when the swap target is <body> or
+//     hx-select is in play, "partial" otherwise. The server is expected to
+//     honor it.
+//
+// This selector treats HX-Request-Type=full as a hard hint to render the Page
+// component. Otherwise it picks the matching key from HX-Target — preferring
+// the id portion of "<tag>#<id>" when present, falling back to the tag for
+// id-less targets — and applies the same matching rules as
+// [HTMXRenderTarget]. A component named e.g. Form matches both
+// `hx-target="#some-form"` (sent as "form#some-form") and `hx-target="form"`
+// (sent as "form").
+//
+// HX-Source (htmx 4's HX-Trigger replacement) identifies the trigger element
+// rather than the swap target, so it is not used for component routing. Read
+// it from the request directly if you need it.
+//
+// See https://four.htmx.org/reference/#headers.
+//
+// Wire it via [WithTargetSelector] when serving an htmx 4 frontend:
+//
+//	sp, err := structpages.Mount(mux, root{}, "/", "App",
+//	    structpages.WithTargetSelector(structpages.HTMXv4RenderTarget))
+func HTMXv4RenderTarget(r *http.Request, pn *PageNode) (RenderTarget, error) {
+	if r.Header.Get("HX-Request") == "true" &&
+		r.Header.Get("HX-Request-Type") != "full" {
+		if key := htmxv4TargetKey(r.Header.Get("HX-Target")); key != "" {
+			if componentName := matchComponentByTarget(key, pn); componentName != "" {
+				method := pn.Components[componentName]
+				return newMethodRenderTarget(componentName, &method), nil
+			}
+			return newFunctionRenderTarget(key, pn.Name), nil
+		}
+	}
+
+	pageMethod := pn.Components["Page"]
+	return newMethodRenderTarget("Page", &pageMethod), nil
+}
+
+// htmxv4TargetKey extracts the matching key from an htmx 4 HX-Target value.
+// The header format is "<tag>#<id>" when the swap target has an id, or just
+// "<tag>" when it doesn't. Prefer the id when available (more specific);
+// otherwise use the tag so components like Form can match `hx-target="form"`.
+func htmxv4TargetKey(target string) string {
+	tag, id, ok := strings.Cut(target, "#")
+	if ok && id != "" {
+		return id
+	}
+	return tag
 }
 
 // matchComponentByTarget finds a component that matches the given HX-Target ID.

--- a/htmx_test.go
+++ b/htmx_test.go
@@ -399,6 +399,146 @@ func TestHTMXRenderTarget_FunctionTarget(t *testing.T) {
 	}
 }
 
+func TestHTMXv4RenderTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		pageNode *PageNode
+		// expected: methodRenderTarget name; "" means expect Page (or fallback).
+		// expectFunction: true if a functionRenderTarget is expected.
+		expected       string
+		expectFunction bool
+	}{
+		{
+			name: "v4 tag#id matches component by id",
+			headers: map[string]string{
+				"HX-Request": "true",
+				"HX-Target":  "main#content",
+			},
+			pageNode: &PageNode{
+				Name:       "Index",
+				Title:      "Index",
+				Components: map[string]reflect.Method{"Content": {}},
+			},
+			expected: "Content",
+		},
+		{
+			name: "v4 tag#id with full prefix",
+			headers: map[string]string{
+				"HX-Request": "true",
+				"HX-Target":  "div#index-todo-list",
+			},
+			pageNode: &PageNode{
+				Name:       "Index",
+				Title:      "Index",
+				Components: map[string]reflect.Method{"TodoList": {}},
+			},
+			expected: "TodoList",
+		},
+		{
+			name: "v4 tag-only target matches component by tag name",
+			headers: map[string]string{
+				"HX-Request": "true",
+				"HX-Target":  "form", // no id - matches Form component
+			},
+			pageNode: &PageNode{
+				Name:       "Index",
+				Title:      "Index",
+				Components: map[string]reflect.Method{"Form": {}, "Page": {}},
+			},
+			expected: "Form",
+		},
+		{
+			name: "v4 tag-only target without matching component returns functionRenderTarget",
+			headers: map[string]string{
+				"HX-Request": "true",
+				"HX-Target":  "div",
+			},
+			pageNode: &PageNode{
+				Name:       "Index",
+				Title:      "Index",
+				Components: map[string]reflect.Method{"Page": {}},
+			},
+			expectFunction: true,
+		},
+		{
+			name: "v4 missing HX-Target falls back to Page",
+			headers: map[string]string{
+				"HX-Request": "true",
+			},
+			pageNode: &PageNode{
+				Name:       "Index",
+				Title:      "Index",
+				Components: map[string]reflect.Method{"Page": {}},
+			},
+			expected: "Page",
+		},
+		{
+			name: "v4 unknown id returns functionRenderTarget",
+			headers: map[string]string{
+				"HX-Request": "true",
+				"HX-Target":  "span#nonexistent",
+			},
+			pageNode: &PageNode{
+				Name:       "Index",
+				Title:      "Index",
+				Components: map[string]reflect.Method{"Page": {}},
+			},
+			expectFunction: true,
+		},
+		{
+			name:    "non-HTMX request returns Page",
+			headers: map[string]string{},
+			pageNode: &PageNode{
+				Name:       "Index",
+				Title:      "Index",
+				Components: map[string]reflect.Method{"Page": {}},
+			},
+			expected: "Page",
+		},
+		{
+			name: "v4 HX-Request-Type=full overrides HX-Target",
+			headers: map[string]string{
+				"HX-Request":      "true",
+				"HX-Request-Type": "full",
+				"HX-Target":       "main#content",
+			},
+			pageNode: &PageNode{
+				Name:       "Index",
+				Title:      "Index",
+				Components: map[string]reflect.Method{"Content": {}, "Page": {}},
+			},
+			expected: "Page",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+			target, err := HTMXv4RenderTarget(req, tt.pageNode)
+			if err != nil {
+				t.Fatalf("HTMXv4RenderTarget: %v", err)
+			}
+			if tt.expectFunction {
+				if _, ok := target.(*functionRenderTarget); !ok {
+					t.Errorf("expected functionRenderTarget, got %T", target)
+				}
+				return
+			}
+			mrt, ok := target.(*methodRenderTarget)
+			if !ok {
+				t.Fatalf("expected methodRenderTarget, got %T", target)
+			}
+			if mrt.name != tt.expected {
+				t.Errorf("got %q, want %q", mrt.name, tt.expected)
+			}
+		})
+	}
+}
+
 func TestHTMXRenderTarget_Default(t *testing.T) {
 	// Test that HTMXRenderTarget is the default target selector
 	sp, _ := Mount(nil, struct{}{}, "/", "Test")


### PR DESCRIPTION
## Summary

- Adds `HTMXv4RenderTarget` for htmx 4, which reshaped two request headers the default selector relies on:
  - `HX-Target` now carries `<tag>#<id>` (or just `<tag>`) instead of a bare id
  - `HX-Request-Type` was added (`full` vs `partial`); `full` short-circuits to `Page()`
  - Selector prefers the id portion when present and falls back to the tag, so a `Form` component matches both `hx-target="#some-form"` (sent as `form#some-form`) and `hx-target="form"` (sent as `form`).
- Adds `structpages/htmltemplate` — a small subpackage with one helper, `Funcs(ctx)`, returning a `template.FuncMap` that binds `urlFor` / `idFor` / `idTarget` so `html/template` authors can call them inline.
- Adds `examples/html-template/` end-to-end: ~12-line `tpl` wrapper implementing `Render(ctx, w) error`, one parsed `(layout + body)` template set per page, and htmx 4 partial swaps via `WithTargetSelector(structpages.HTMXv4RenderTarget)`. The example demonstrates that structpages is render-engine agnostic.

The default `HTMXRenderTarget` is unchanged — wire `HTMXv4RenderTarget` explicitly when serving an htmx 4 frontend.

## Test plan

- [x] `go test ./...` (library + `htmltemplate` package)
- [x] New unit tests cover: `tag#id` matching, tag-only matching, unmatched id → functionRenderTarget, missing/non-HTMX request, `HX-Request-Type=full` override.
- [x] Manual smoke test of `examples/html-template/`: full GET, htmx 4 partial swap (`HX-Target: main#main`), tag-only swap (`HX-Target: main`), and `HX-Request-Type: full` override all behave correctly.
- [ ] Reviewer to confirm `htmltemplate.Funcs(nil)` placeholder / per-request rebind pattern is the API surface they want (only one helper added; struct/`Renderer` wrapper deliberately not added).