### PR TITLE
feat(lint): recognise // comments for url-attr suppression in .templ

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,15 @@ Categories:
 - `urlfor`, `ref`, `id`, `idtarget`, `params` — checks `structpages.URLFor` / `Ref` / `ID` / `IDTarget` call sites against the reconstructed page tree.
 - `url-attr` — scans `.templ` files for URL-bearing HTML attributes (`href`, `action`, `formaction`, `hx-{get,post,put,patch,delete}`, `hx-{push,replace}-url`) whose values are hard-coded internal paths, string concatenations, or `fmt.Sprint*` calls — i.e. cases where you should have called `structpages.URLFor`. Allows `https://`, `mailto:`, `#`, protocol-relative `//`.
 
-Suppress a single diagnostic with a comment:
+Suppress a single diagnostic with a comment. Prefer `//` in both file types — Go-style comments are stripped from the generated HTML; `<!-- … -->` HTML comments render into every response.
 
 ```go
 //structpages:lint:ignore url-attr           // in .go files
 ```
 
-```html
-<!-- structpages:lint:ignore url-attr -->    <!-- in .templ files -->
+```templ
+// structpages:lint:ignore url-attr          // in .templ files (preferred)
+<!-- structpages:lint:ignore url-attr -->    <!-- also works in .templ -->
 ```
 
 ## Claude Code Skill

--- a/skills/structpages/SKILL.md
+++ b/skills/structpages/SKILL.md
@@ -328,17 +328,19 @@ go install github.com/jackielii/structpages/tools/lint/cmd/structpages-lint@late
 structpages-lint ./...
 ```
 
-Suppress a single diagnostic with a comment:
+Suppress a single diagnostic with a comment. **Prefer `//` in both `.go` and `.templ`** — Go-style comments are stripped from the generated HTML, while `<!-- … -->` HTML comments render into every response.
 
 ```go
 //structpages:lint:ignore url-attr
 url := structpages.URLFor(...)            // in .go files
 ```
 
-```html
-<!-- structpages:lint:ignore url-attr -->
-<a href="/legacy">…</a>                    <!-- in .templ files -->
+```templ
+// structpages:lint:ignore url-attr
+<a href="/legacy">…</a>                    // in .templ files (preferred)
 ```
+
+`<!-- structpages:lint:ignore url-attr -->` also works in `.templ` for the rare case where you actually want the directive visible to anyone viewing source, but the `//` form is the default.
 
 The directive applies to its own line and the line immediately below, so placing it above an element works the same as inline. Multiple categories are comma-separated; bare `structpages:lint:ignore` suppresses every category on that line.
 

--- a/skills/structpages/reference.md
+++ b/skills/structpages/reference.md
@@ -353,11 +353,11 @@ Diagnostic categories:
 | `params` | `URLFor` params that don't appear in the route pattern. |
 | `url-attr` | URL-bearing HTML attributes in `.templ` files (`href`, `action`, `formaction`, `hx-{get,post,put,patch,delete}`, `hx-{push,replace}-url`) whose values are hard-coded internal paths, string concats, or `fmt.Sprint*` calls. |
 
-Suppression syntax:
+Suppression syntax (place above the call/element, or on the same line):
 
-| Source | Directive |
-|---|---|
-| `.go` files | `//structpages:lint:ignore <category>[,…]` on the line above the call (or same line). |
-| `.templ` files | `<!-- structpages:lint:ignore <category>[,…] -->` on the line above the element (or same line). |
+| Source | Preferred | Also supported |
+|---|---|---|
+| `.go` files | `//structpages:lint:ignore <category>[,…]` | — |
+| `.templ` files | `// structpages:lint:ignore <category>[,…]` (Go-style; stripped from HTML output) | `<!-- structpages:lint:ignore <category>[,…] -->` (renders into HTML, prefer only when intentional) |
 
 A bare directive with no category suppresses every category on the targeted line. Categories are comma-separated.

--- a/tools/lint/templscan/directive.go
+++ b/tools/lint/templscan/directive.go
@@ -75,3 +75,10 @@ func parseDirective(commentBody string) (cats []string, ok bool) {
 func commentLine(n *parser.HTMLComment) int {
 	return int(n.Range.From.Line) + 1
 }
+
+// goCommentLine returns the 1-indexed source line of a Go-style
+// // comment in templ. Multiline /* */ comments would need a
+// different mapping; we only handle single-line here.
+func goCommentLine(n *parser.GoComment) int {
+	return int(n.Range.From.Line) + 1
+}

--- a/tools/lint/templscan/directive_test.go
+++ b/tools/lint/templscan/directive_test.go
@@ -20,3 +20,23 @@ func TestScan_HonoursHTMLCommentSuppression(t *testing.T) {
 		t.Errorf("the surviving diagnostic should be for /dashboard, got %q", diags[0].Message)
 	}
 }
+
+// TestScan_HonoursGoCommentSuppression covers the preferred form
+// for .templ suppression: a Go-style // comment, which is stripped
+// from the generated HTML (unlike <!-- ... --> which renders into
+// every response).
+func TestScan_HonoursGoCommentSuppression(t *testing.T) {
+	diags, err := Scan("testdata/suppression_gocomment.templ", nil)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(diags) != 1 {
+		for _, d := range diags {
+			t.Logf("diag: %s:%d:%d %s", d.Filename, d.Line, d.Col, d.Message)
+		}
+		t.Fatalf("want 1 unsuppressed diagnostic, got %d", len(diags))
+	}
+	if !strings.Contains(diags[0].Message, `"/dashboard"`) {
+		t.Errorf("the surviving diagnostic should be for /dashboard, got %q", diags[0].Message)
+	}
+}

--- a/tools/lint/templscan/scan.go
+++ b/tools/lint/templscan/scan.go
@@ -61,6 +61,19 @@ func Scan(filename string, _ SuppressLookup) ([]Diagnostic, error) {
 		ds.add(commentLine(n), cats)
 		return nil
 	}
+	v.GoComment = func(n *parser.GoComment) error {
+		// Multi-line /* */ comments may span multiple source
+		// lines; the directive only suppresses the line the
+		// comment starts on plus the following line, matching
+		// the // form's semantics. Authors who want to suppress
+		// a block should put the directive on its own line.
+		cats, ok := parseDirective(n.Contents)
+		if !ok {
+			return nil
+		}
+		ds.add(goCommentLine(n), cats)
+		return nil
+	}
 	v.ConstantAttribute = func(n *parser.ConstantAttribute) error {
 		key, ok := n.Key.(parser.ConstantAttributeKey)
 		if !ok {

--- a/tools/lint/templscan/testdata/suppression_gocomment.templ
+++ b/tools/lint/templscan/testdata/suppression_gocomment.templ
@@ -1,0 +1,14 @@
+package fixture
+
+templ SuppressedGoComment() {
+	// structpages:lint:ignore url-attr
+	<a href="/login">Suppressed (Go-comment above)</a>
+
+	// structpages:lint:ignore
+	<a href="/admin">Suppressed (all categories)</a>
+
+	// structpages:lint:ignore url-attr,ref
+	<a href="/help">Suppressed (multi-category)</a>
+
+	<a href="/dashboard">Not suppressed</a>
+}


### PR DESCRIPTION
## Summary

- The `url-attr` suppression directive now accepts `// structpages:lint:ignore url-attr` (Go-style) in `.templ` files, in addition to the existing `<!-- structpages:lint:ignore -->` form.
- `//` is the preferred form: templ strips it during code generation, so it never reaches the rendered HTML. `<!-- … -->` HTML comments survive into every response, which is rarely what you want for a lint directive.
- Docs (README, SKILL.md, reference.md) updated to recommend `//` and keep `<!-- … -->` documented as a fallback.

Wires templ's `GoComment` visitor through the same `parseDirective` + `directiveSet` path used for `HTMLComment`.

## Test Plan

- [ ] `cd tools/lint && go test ./templscan/...` — new `TestScan_HonoursGoCommentSuppression` exercises the `//` form (own line, line above, multi-category, bare-suppress-all variants)
- [ ] Existing `TestScan_HonoursHTMLCommentSuppression` still passes (no regression on the `<!-- -->` path)
- [ ] `cd examples/lint-misuse && go test ./...` — end-to-end snapshot unchanged