### PR TITLE
fix(lint): drop replace directive blocking go install

### DIFF
--- a/tools/lint/go.mod
+++ b/tools/lint/go.mod
@@ -13,5 +13,3 @@ require (
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 )
-
-replace github.com/jackielii/structpages => ../..


### PR DESCRIPTION
## Summary

`go install github.com/jackielii/structpages/tools/lint/cmd/structpages-lint@v0.1.1` fails with:

> The go.mod file for the module providing named packages contains one or more replace directives. It must not contain directives that would cause it to be interpreted differently than if it were the main module.

The replace was a development-only convenience; `tools/lint` doesn't actually import `github.com/jackielii/structpages` (only references its name as a string constant in `tree.go`), so dropping the replace has no effect on local builds or tests.

## Test Plan

- [ ] `cd tools/lint && go test ./...` passes
- [ ] `cd examples/lint-misuse && go test ./...` passes (still builds the binary from the in-tree source)
- [ ] After merge + tag `tools/lint/v0.1.2`: `go install github.com/jackielii/structpages/tools/lint/cmd/structpages-lint@v0.1.2` succeeds