### PR TITLE
fix(lint): bump tools/lint to go 1.26 so installed binary can parse 1.26 projects

### DIFF
--- a/tools/lint/go.mod
+++ b/tools/lint/go.mod
@@ -1,6 +1,6 @@
 module github.com/jackielii/structpages/tools/lint
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/a-h/templ v0.3.1020


### PR DESCRIPTION
## Summary

A binary built against Go 1.25 fails to load Go 1.26 projects because the stdlib parser doesn't recognize 1.26 syntax. \`go install ...@latest\` of the lint tool against a 1.26 codebase (\`~/work/his-project\`) currently surfaces ~250 \"file requires newer Go version\" errors before any analyzer runs.

Bumping \`tools/lint/go.mod\` to \`go 1.26.0\` makes \`go install\` auto-fetch the 1.26 toolchain via \`GOTOOLCHAIN=auto\`, producing a binary that can analyze the latest projects.

### Note: CI gap

CI's \`test\` job runs \`go test ./...\` from repo root — that only covers the **main** module. \`tools/lint\` tests aren't part of the matrix at all, so this PR's CI run won't actually exercise the new go version. Local \`GOTOOLCHAIN=go1.26.0 go test ./...\` in \`tools/lint\` is green. Adding tools/lint to CI is a separate followup.

## Test Plan

- [ ] Local: \`cd tools/lint && GOTOOLCHAIN=go1.26.0 go test ./...\` passes
- [ ] After release: \`go install github.com/jackielii/structpages/tools/lint/cmd/structpages-lint@v0.1.3\` succeeds
- [ ] The installed binary runs cleanly on a Go 1.26 project without \"requires newer Go version\" errors