### PR TITLE
fix(docs): MDX-compatible autolink and broader link rewrite

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,10 +63,16 @@ jobs:
             printf -- '---\n\n'
             cat main/examples/README.md
           } > site/docs/examples/index.md
-          # Rewrite cross-directory relative links to absolute GitHub URLs.
+          # Rewrite cross-directory `../X` links (any sibling of docs/) to
+          # absolute GitHub URLs so they resolve on the rendered site.
           find site/docs -name '*.md' -print0 | xargs -0 sed -i -E \
-            -e 's#\]\(\.\./examples/([^)]+)\)#](https://github.com/jackielii/structpages/tree/main/examples/\1)#g' \
-            -e 's#\]\(\.\./skills/([^)]+)\)#](https://github.com/jackielii/structpages/tree/main/skills/\1)#g'
+            -e 's#\]\(\.\./([^)]+)\)#](https://github.com/jackielii/structpages/tree/main/\1)#g'
+          # Examples README uses `./<name>/` links (relative to examples/).
+          # In docs/examples/index.md those would resolve to /structpages/<name>
+          # which doesn't exist, so rewrite to absolute GitHub URLs.
+          sed -i -E \
+            -e 's#\]\(\./([^)]+/?)\)#](https://github.com/jackielii/structpages/tree/main/examples/\1)#g' \
+            site/docs/examples/index.md
 
       - name: Generate package reference
         run: |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -89,7 +89,7 @@ go tool templ generate -include-version=false
 go run .
 ```
 
-Open <http://localhost:8080>. You should see "Hello, structpages!" and a link to `/about`.
+Open [http://localhost:8080](http://localhost:8080). You should see "Hello, structpages!" and a link to `/about`.
 
 ## What just happened
 


### PR DESCRIPTION
First docs-site deploy failed because:
1. `docs/quick-start.md` line 92 used the markdown autolink form `<http://localhost:8080>`, which MDX parses as a JSX tag and rejects.
2. The workflow's sed rewrite of relative cross-dir links was too narrow — only `../examples/` and `../skills/` were handled. `../tools/lint` (in expanded urlfor.md) and `./<name>/` links inside the copied `examples/README.md` (now `docs/examples/index.md`) leaked through and caused broken-link warnings.

## Changes
- Use `[http://...](http://...)` form in quick-start.md
- Broaden sed: `../<any-dir>/X` → `https://github.com/jackielii/structpages/tree/main/<dir>/X`
- Add second sed pass for `./<name>/` links specific to docs/examples/index.md

## Test plan
Verified locally: `npm run build` in `website/` (with main's docs copied in + sed applied) succeeds with no broken-link warnings.