### PR TITLE
feat: Parse + StructPages.PageContext for test harnesses

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,10 +63,16 @@ jobs:
             printf -- '---\n\n'
             cat main/examples/README.md
           } > site/docs/examples/index.md
-          # Rewrite cross-directory relative links to absolute GitHub URLs.
+          # Rewrite cross-directory `../X` links (any sibling of docs/) to
+          # absolute GitHub URLs so they resolve on the rendered site.
           find site/docs -name '*.md' -print0 | xargs -0 sed -i -E \
-            -e 's#\]\(\.\./examples/([^)]+)\)#](https://github.com/jackielii/structpages/tree/main/examples/\1)#g' \
-            -e 's#\]\(\.\./skills/([^)]+)\)#](https://github.com/jackielii/structpages/tree/main/skills/\1)#g'
+            -e 's#\]\(\.\./([^)]+)\)#](https://github.com/jackielii/structpages/tree/main/\1)#g'
+          # Examples README uses `./<name>/` links (relative to examples/).
+          # In docs/examples/index.md those would resolve to /structpages/<name>
+          # which doesn't exist, so rewrite to absolute GitHub URLs.
+          sed -i -E \
+            -e 's#\]\(\./([^)]+/?)\)#](https://github.com/jackielii/structpages/tree/main/examples/\1)#g' \
+            site/docs/examples/index.md
 
       - name: Generate package reference
         run: |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Route definitions use the format `[method] path [Title]`:
 - [URLFor & ID Generation](./docs/urlfor.md) - Type-safe URL and HTML id generation
 - [Templ Patterns](./docs/templ.md) - Working with Templ templates
 - [Advanced Features](./docs/advanced.md) - Dependency injection, Init, dynamic Refs, type aliases
+- [Testing renders](./skills/structpages/SKILL.md#8-testing-renders-with-a-bare-context) - `structpages.Parse` + `sp.PageContext(ctx)` for unit tests that render templ components without an HTTP server
 
 ## Examples
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -89,7 +89,7 @@ go tool templ generate -include-version=false
 go run .
 ```
 
-Open <http://localhost:8080>. You should see "Hello, structpages!" and a link to `/about`.
+Open [http://localhost:8080](http://localhost:8080). You should see "Hello, structpages!" and a link to `/about`.
 
 ## What just happened
 

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@ Read these files in order to learn the library: `README.md` for the elevator pit
 ## Docs
 
 - [README](https://raw.githubusercontent.com/jackielii/structpages/main/README.md): Overview, features, install, quick-start, and links to documentation and examples.
-- [API reference](https://raw.githubusercontent.com/jackielii/structpages/main/docs/api.md): Signatures for `Mount`, `StructPages`, options (`WithMiddlewares`, `WithArgs`, `WithErrorHandler`, `WithURLPrefix`), and methods (`Page`, `Content`, `Props`, `ServeHTTP`, `Middlewares`, `Init`).
+- [API reference](https://raw.githubusercontent.com/jackielii/structpages/main/docs/api.md): Signatures for `Mount`, `Parse` (no-mux variant for tests/tooling), `StructPages` (including `PageContext` for injecting the page tree into a `context.Background()` so renders can call URLFor/ID/IDTarget), options (`WithMiddlewares`, `WithArgs`, `WithErrorHandler`, `WithURLPrefix`), and methods (`Page`, `Content`, `Props`, `ServeHTTP`, `Middlewares`, `Init`).
 - [Routing patterns](https://raw.githubusercontent.com/jackielii/structpages/main/docs/routing.md): Route tag syntax (`route:"[METHOD] /path [Title]"`), nested routes, path parameters, and registration order.
 - [Supported request flows](https://raw.githubusercontent.com/jackielii/structpages/main/docs/supported-flows.md): How requests dispatch to handlers and components (`Page`/`Content`/partial methods, `Props`-only pages, `ServeHTTP` pages, render targets).
 - [Middleware](https://raw.githubusercontent.com/jackielii/structpages/main/docs/middleware.md): Global vs per-page middleware, the `MiddlewareFunc` signature, and using the `*PageNode` argument.

--- a/parse_public.go
+++ b/parse_public.go
@@ -1,0 +1,58 @@
+package structpages
+
+import (
+	"context"
+)
+
+// Parse builds a page tree from page without registering any HTTP
+// routes. The returned *StructPages exposes URLFor, ID, IDTarget,
+// and PageContext, but never touches a mux.
+//
+// Use Parse for tests and tooling that need URL/ID resolution
+// against the real page tree but don't want to spin up a server.
+// For production use, prefer Mount, which performs the same parse
+// step and additionally registers handlers.
+//
+// Options behave identically to Mount: WithArgs, WithURLPrefix,
+// WithErrorHandler, etc. all apply. WithMiddlewares and other
+// mux-affecting options are accepted but never observed (no
+// handlers are wired).
+//
+// Example (test):
+//
+//	sp, err := structpages.Parse(webPages{}, "/", "App")
+//	if err != nil { t.Fatal(err) }
+//	ctx := sp.PageContext(context.Background())
+//	body := renderTo(ctx, List{}.Page(props))
+func Parse(page any, route, title string, options ...Option) (*StructPages, error) {
+	sp := &StructPages{
+		targetSelector: HTMXRenderTarget,
+	}
+	for _, opt := range options {
+		opt(sp)
+	}
+	pc, err := parsePageTree(route, page, sp.args...)
+	if err != nil {
+		return nil, err
+	}
+	pc.root.Title = title
+	pc.urlPrefix = sp.urlPrefix
+	sp.pc = pc
+	return sp, nil
+}
+
+// PageContext returns a context derived from ctx with sp's page
+// tree attached. URLFor, ID, and IDTarget invoked with the returned
+// context resolve against sp instead of failing with "parse context
+// not found in context".
+//
+// Use this in tests that render templ components with
+// context.Background(): wrap the bare context once via PageContext
+// and the renders behave as if they ran under a real request.
+//
+//	sp, _ := structpages.Parse(webPages{}, "/", "App")
+//	ctx := sp.PageContext(context.Background())
+//	html := mustRender(ctx, MyPage{}.Page(props))
+func (sp *StructPages) PageContext(ctx context.Context) context.Context {
+	return pcCtx.WithValue(ctx, sp.pc)
+}

--- a/parse_public_test.go
+++ b/parse_public_test.go
@@ -1,0 +1,83 @@
+package structpages_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jackielii/structpages"
+)
+
+type parsePubHome struct{}
+
+func (parsePubHome) ServeHTTP(http.ResponseWriter, *http.Request) {}
+
+type parsePubItem struct{}
+
+func (parsePubItem) ServeHTTP(http.ResponseWriter, *http.Request) {}
+
+type parsePubRoot struct {
+	Home parsePubHome `route:"/ Home"`
+	Item parsePubItem `route:"/items/{id} Item"`
+}
+
+// TestParse_BuildsTreeWithoutMounting verifies that Parse returns a
+// usable *StructPages whose URLFor resolves against the page tree,
+// without ever registering routes on a mux.
+func TestParse_BuildsTreeWithoutMounting(t *testing.T) {
+	sp, err := structpages.Parse(parsePubRoot{}, "/", "Test")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	got, err := sp.URLFor(parsePubHome{})
+	if err != nil {
+		t.Fatalf("URLFor Home: %v", err)
+	}
+	if got != "/" {
+		t.Errorf("URLFor Home = %q, want %q", got, "/")
+	}
+
+	got, err = sp.URLFor(parsePubItem{}, map[string]any{"id": 42})
+	if err != nil {
+		t.Fatalf("URLFor Item: %v", err)
+	}
+	if got != "/items/42" {
+		t.Errorf("URLFor Item = %q, want %q", got, "/items/42")
+	}
+}
+
+// TestParse_DoesNotTouchMux confirms Parse skips the mux-registration
+// step entirely — a freshly created ServeMux stays empty.
+func TestParse_DoesNotTouchMux(t *testing.T) {
+	mux := http.NewServeMux()
+	if _, err := structpages.Parse(parsePubRoot{}, "/", "Test"); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 on empty mux, got %d (Parse must not register routes)", rec.Code)
+	}
+}
+
+// TestPageContext_EnablesURLForOnBareContext is the test-harness
+// motivating use case: a template render with a bare
+// context.Background() can call URLFor after wrapping with
+// PageContext.
+func TestPageContext_EnablesURLForOnBareContext(t *testing.T) {
+	sp, err := structpages.Parse(parsePubRoot{}, "/", "Test")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	ctx := sp.PageContext(context.Background())
+
+	got, err := structpages.URLFor(ctx, parsePubItem{}, map[string]any{"id": 7})
+	if err != nil {
+		t.Fatalf("URLFor: %v", err)
+	}
+	if got != "/items/7" {
+		t.Errorf("URLFor = %q, want %q", got, "/items/7")
+	}
+}

--- a/skills/structpages/SKILL.md
+++ b/skills/structpages/SKILL.md
@@ -468,6 +468,29 @@ Generic types and interface types are supported as well — see `generics_inject
 
 `*PageNode` is always available for injection (the framework adds the current node automatically).
 
+### 8. Testing renders with a bare context
+
+Unit tests that render templ components directly — without spinning up an HTTP server — need a page tree in `context.Background()` so calls to `URLFor` / `ID` / `IDTarget` resolve. Use `structpages.Parse` (builds the tree, no mux) and `sp.PageContext(ctx)` (wraps ctx with the tree):
+
+```go
+sp, err := structpages.Parse(webPages{}, "/", "App",
+    structpages.WithArgs(fakeAppCtx),
+)
+if err != nil { t.Fatal(err) }
+ctx := sp.PageContext(context.Background())
+
+// Now URLFor in templ components and props helpers resolves against webPages{}.
+buf := &bytes.Buffer{}
+if err := MyPage{}.Page(props).Render(ctx, buf); err != nil { t.Fatal(err) }
+```
+
+This is the recommended fix for two patterns that fail under bare-context renders:
+
+1. **Component-level renders with handcrafted props.** Props is hand-rolled; the only framework dep is `URLFor` in the templ. `sp.PageContext` is a one-line wrap.
+2. **Cross-module URL refs (e.g. appshell linking to `Home` in a sibling module).** Mount only one sub-tree on a test mux and `URLFor` to siblings outside it fails. Building the canonical root via `Parse(webPages{}, ...)` gives the tree those refs need, without registering any routes.
+
+`Parse` accepts the same options as `Mount` — `WithArgs` for DI args used by `Props`, `WithURLPrefix` if the test asserts prefixed URLs, etc. Mux-shaped options (middlewares) are accepted but inert since no handlers register.
+
 ## Key Rules
 
 1. **Props methods extract path params** via `r.PathValue("param")`, not function arguments.

--- a/skills/structpages/reference.md
+++ b/skills/structpages/reference.md
@@ -14,17 +14,28 @@ Main entry point. Parses page tree, registers routes on mux, returns `*StructPag
 - `title`: Root page title
 - `options`: `WithArgs`, `WithErrorHandler`, `WithMiddlewares`, `WithTargetSelector`, `WithWarnEmptyRoute`
 
+## Parse (no-mux variant)
+
+```go
+func Parse(page any, route, title string, options ...Option) (*StructPages, error)
+```
+
+Builds the page tree without registering any routes on a mux. Use in tests and tooling that need URLFor/ID/IDTarget against the real page tree but don't want an HTTP server. Accepts the same options as `Mount`; mux-shaped options (middlewares) are inert.
+
 ## StructPages Type
 
-Returned by `Mount()`. Methods:
+Returned by `Mount()` and `Parse()`. Methods:
 
 ```go
 func (sp *StructPages) URLFor(page any, args ...any) (string, error)
 func (sp *StructPages) ID(v any) (string, error)
 func (sp *StructPages) IDTarget(v any) (string, error)
+func (sp *StructPages) PageContext(ctx context.Context) context.Context
 ```
 
-Use these outside of request context (e.g., during initialization). Within request handlers, use the context-based versions.
+`PageContext` wraps `ctx` with `sp`'s page tree so the context-form `URLFor` / `ID` / `IDTarget` (in templ renders, props helpers) resolve against `sp`. The recommended test pattern: `Parse` once per package, wrap a bare `context.Background()` in `PageContext`, render against the wrapped ctx.
+
+Use the method form of `URLFor`/`ID`/`IDTarget` outside of request context (e.g., during initialization). Within request handlers, use the context-based versions.
 
 ## Context Functions
 


### PR DESCRIPTION
## Summary

Adds two new public API surfaces — \`structpages.Parse(...)\` and \`(*StructPages).PageContext(ctx)\` — that let tests build the page tree and inject it into \`context.Background()\` without registering any HTTP routes.

\`\`\`go
sp, err := structpages.Parse(webPages{}, \"/\", \"App\", structpages.WithArgs(fakeAppCtx))
if err != nil { t.Fatal(err) }
ctx := sp.PageContext(context.Background())

buf := &bytes.Buffer{}
_ = MyPage{}.Page(props).Render(ctx, buf)  // URLFor inside resolves correctly
\`\`\`

### Why

The url-attr lint check (shipped in v0.3.1) catches hard-coded internal URLs in templ. Migrating them to \`URLFor\` is the right call, but two test patterns currently make that hard:

- Component-level unit tests render with bare \`context.Background()\` → \`URLFor\` returns \"parse context not found in context\".
- Sub-root mounts in tests can only see their own sub-tree, so \`URLFor\` to siblings (e.g. an appshell linking to \`Home\` in another module) fails.

\`Parse\` + \`PageContext\` is the orthogonal primitive: build the tree once, inject into ctx, done. No mux, no DI of every Service, no test giving up isolation.

### Why not 'string-as-Ref' sugar

Considered, dropped: the asymmetry between \`URLFor(\"PageName\")\` (great) and \`IDTarget(\"body\")\` (currently legitimate literal, would break) would confuse users. \`Ref(\"...\")\` stays the explicit form for both URL and ID lookups.

## Test Plan

- [ ] \`go test ./...\` — new \`TestParse_BuildsTreeWithoutMounting\`, \`TestParse_DoesNotTouchMux\`, \`TestPageContext_EnablesURLForOnBareContext\`
- [ ] No regressions: full suite green
- [ ] Try the pattern in \`~/work/his-project\` after release