### PR TITLE
feat(urlfor): accept string at top level as auto-Ref

### DIFF
--- a/examples/lint-misuse/lint_test.go
+++ b/examples/lint-misuse/lint_test.go
@@ -31,6 +31,7 @@ pages.go:LINE:COL: [urlfor] URLFor chain: parent Items has no child of type home
 pages.go:LINE:COL: [urlfor] URLFor: typed value at slice position 2 follows a string fragment; chain steps must all come before any string fragment
 pages.go:LINE:COL: [params] URLFor: param "wrong" does not appear in pattern "/items/{slug}" (known: slug)
 pages.go:LINE:COL: [idfor] IDTarget: method expression unmountedPage.Title: receiver type unmountedPage is not mounted as a page
+pages.go:LINE:COL: [ref] Ref "Items.NoSuch": segment 1 ("NoSuch") not found as child of "Items"; available: Detail, Index
 pages.templ:LINE:COL: [url-attr] href value "/login" is a hard-coded internal URL; use structpages.URLFor instead
 pages.templ:LINE:COL: [url-attr] href value "/admin" is a hard-coded internal URL; use structpages.URLFor instead
 pages.templ:LINE:COL: [url-attr] href value ` + "`" + `"/items/" + strconv.Itoa(id)` + "`" + ` builds an internal URL by string concatenation; use structpages.URLFor instead

--- a/examples/lint-misuse/pages.go
+++ b/examples/lint-misuse/pages.go
@@ -94,6 +94,13 @@ func urlSamples(ctx context.Context) {
 	var d itemDetail
 	_, _ = structpages.IDTarget(ctx, d.Stats)
 
+	// BAD: ref/string — top-level string is sugar for Ref; the analyzer
+	// validates string args to URLFor the same way it validates Ref(...).
+	_, _ = structpages.URLFor(ctx, "Items.NoSuch")
+
+	// OK: bare string that resolves to a real page name.
+	_, _ = structpages.URLFor(ctx, "Home")
+
 	// OK: would be a [ref] diagnostic but directive on previous line silences it.
 	//structpages:lint:ignore ref
 	_, _ = structpages.URLFor(ctx, structpages.Ref("Suppressed"))

--- a/parse_public_test.go
+++ b/parse_public_test.go
@@ -62,6 +62,63 @@ func TestParse_DoesNotTouchMux(t *testing.T) {
 	}
 }
 
+// TestURLFor_StringIsRef verifies the auto-Ref sugar: a top-level
+// string arg to URLFor is treated as Ref(string), so
+// URLFor(ctx, "Home") behaves like URLFor(ctx, Ref("Home")). The
+// motivation is ergonomics for cross-module calls where importing
+// the page type would cycle.
+func TestURLFor_StringIsRef(t *testing.T) {
+	sp, err := structpages.Parse(parsePubRoot{}, "/", "Test")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	ctx := sp.PageContext(context.Background())
+
+	cases := []struct {
+		name, input, want string
+	}{
+		{"page name", "Home", "/"},
+		{"qualified path", "parsePubRoot.Home", "/"},
+		{"route literal", "/", "/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := structpages.URLFor(ctx, tc.input)
+			if err != nil {
+				t.Fatalf("URLFor(%q): %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("URLFor(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("with params", func(t *testing.T) {
+		got, err := structpages.URLFor(ctx, "Item", map[string]any{"id": 9})
+		if err != nil {
+			t.Fatalf("URLFor: %v", err)
+		}
+		if got != "/items/9" {
+			t.Errorf("URLFor = %q, want /items/9", got)
+		}
+	})
+
+	t.Run("strings inside []any stay as fragments", func(t *testing.T) {
+		// Inside the slice form, a string is a URL fragment, not a Ref.
+		// This preserves the existing chain-plus-fragment composition
+		// (e.g. []any{ParentPage{}, "?tab={t}"}).
+		got, err := structpages.URLFor(ctx,
+			[]any{parsePubItem{}, "?ref={r}"},
+			map[string]any{"id": 3, "r": "x"})
+		if err != nil {
+			t.Fatalf("URLFor with fragment: %v", err)
+		}
+		if got != "/items/3?ref=x" {
+			t.Errorf("URLFor = %q, want /items/3?ref=x", got)
+		}
+	})
+}
+
 // TestPageContext_EnablesURLForOnBareContext is the test-harness
 // motivating use case: a template render with a bare
 // context.Background() can call URLFor after wrapping with

--- a/skills/structpages/SKILL.md
+++ b/skills/structpages/SKILL.md
@@ -193,7 +193,8 @@ url, err := structpages.URLFor(ctx,
 | bare typed page | `URLFor(ctx, MyPage{}, params)` | the type is mounted exactly once |
 | typed chain | `URLFor(ctx, []any{Parent{}, Leaf{}}, params)` | same leaf type mounted under multiple parents — parent disambiguates |
 | chain + URL fragment | `URLFor(ctx, []any{Parent{}, Leaf{}, "?tab={t}"}, params)` | need to append a query template or path suffix |
-| Ref by qualified name | `URLFor(ctx, Ref("Parent.Field"), params)` | can't import the page type (cross-package import cycle) |
+| string (auto-Ref) | `URLFor(ctx, "Parent.Field", params)` | can't import the page type (cross-package cycle). Equivalent to `Ref("Parent.Field")` — top-level strings only; strings inside `[]any` are still URL fragments. |
+| Ref by qualified name | `URLFor(ctx, Ref("Parent.Field"), params)` | explicit form of the string sugar above; pick whichever reads better at the call site |
 
 **Always strict.** A bare type that matches multiple nodes errors instead of silently picking one. The error lists every match and recommends the chain form. There is no opt-out — silent first-match is always wrong, so disambiguating at the call site is mandatory.
 
@@ -502,7 +503,7 @@ This is the recommended fix for two patterns that fail under bare-context render
 7. **Promoted (embedded) methods are skipped** — only methods defined directly on the struct count.
 8. **URL params auto-fill from current request's route only** — sibling routes with different param names do not auto-fill.
 9. **`ErrSkipPageRender` is only honored from `Props`** (e.g. after writing a redirect). Returning it from `ServeHTTP` does nothing special.
-10. **Disambiguation primitives:** when the same page type is mounted under multiple parents, use the `[]any{ParentPage{}, LeafPage{}}` chain form — strict `URLFor` (the default) errors on bare lookups. Use `structpages.Ref("Parent.Field")` (qualified path) or `Ref("PageName")` when a package needs to URL-to a page it can't import (importing would cycle); Ref also handles Go type aliases that collapse to one `reflect.Type`. Ref strings are validated at startup via the init-time validator pattern (see §3 "Validating URLs").
+10. **Disambiguation primitives:** when the same page type is mounted under multiple parents, use the `[]any{ParentPage{}, LeafPage{}}` chain form — strict `URLFor` (the default) errors on bare lookups. When a package needs to URL-to a page it can't import (importing would cycle), pass a string as the page arg — `URLFor(ctx, "Parent.Field", ...)` — or use the explicit `Ref("Parent.Field")` form; both resolve the same way. Ref also handles Go type aliases that collapse to one `reflect.Type`. Ref strings are validated at startup via the init-time validator pattern (see §3 "Validating URLs") and by `structpages-lint` (which also validates string args to `URLFor`).
 11. **Plain strings pass through `ID` and `IDTarget` unchanged** — `IDTarget("body")` returns `"body"`, not `"#body"`.
 12. **The `form:` struct tag is not read by the framework** — only `route:` is. Anything else on a route field is ignored.
 13. **Never write `w` (e.g. `http.Error`) in `Props` or an error-returning `ServeHTTP`** — they are buffered; return the error instead. Use a typed error like `ErrorWithStatus` for a specific status code. API/JSON endpoints use the no-error `ServeHTTP(w, r, deps...)` form, where direct writes are correct (see examples.md §13).

--- a/skills/structpages/reference.md
+++ b/skills/structpages/reference.md
@@ -314,8 +314,8 @@ type Ref string
 ```
 
 Dynamic references for URLFor/ID/IDTarget:
-- URLFor: `Ref("PageName")` by name, `Ref("Parent.Field")` qualified path
-- ID: `Ref("PageName.MethodName")` qualified, `Ref("MethodName")` if unambiguous
+- URLFor: `Ref("PageName")` by name, `Ref("Parent.Field")` qualified path. **URLFor also accepts a plain string at the top level as sugar** — `URLFor(ctx, "Parent.Field")` is equivalent to `URLFor(ctx, Ref("Parent.Field"))`. Strings inside `[]any{...}` composition are still URL fragments.
+- ID: `Ref("PageName.MethodName")` qualified, `Ref("MethodName")` if unambiguous. ID/IDTarget do **not** accept the string-as-Ref sugar — plain strings to ID/IDTarget are returned as literal IDs/selectors (e.g. `IDTarget(ctx, "body")` returns `"body"`). Use `Ref(...)` explicitly when you mean dynamic lookup.
 
 ## Mux Interface
 

--- a/tools/lint/urlfor.go
+++ b/tools/lint/urlfor.go
@@ -58,6 +58,13 @@ func resolvePageArg(ctx *checkCtx, expr ast.Expr) *PageNode {
 		return nil
 	}
 
+	// String literal (or named string constant) at the page slot is
+	// sugar for Ref(...): URLFor(ctx, "Admin.Settings"). Validate it
+	// the same way Ref conversions are validated.
+	if s, ok := stringConstantFromPass(ctx, expr); ok {
+		return resolveRef(ctx, expr.Pos(), s, false)
+	}
+
 	// Bare typed value: composite literal, &composite, or named value.
 	t := normalisedPageType(ctx.pass.TypesInfo, expr)
 	if t == nil {

--- a/url_for.go
+++ b/url_for.go
@@ -72,6 +72,15 @@ func extractURLParams(next http.Handler, node *PageNode) http.Handler {
 // URLFor returns the URL for a given page type. If args is provided, it'll replace
 // the path segments. Supported format is similar to http.ServeMux.
 //
+// The page argument accepts:
+//   - a typed page value: URLFor(ctx, Page{}, ...)
+//   - a top-level string (sugar for Ref): URLFor(ctx, "Admin.Settings", ...)
+//     resolves the same as URLFor(ctx, Ref("Admin.Settings"), ...). Useful at
+//     call sites that can't import the target page (cross-package cycle).
+//   - a Ref: URLFor(ctx, Ref("PageName"), ...)
+//   - a []any composition (chain + optional URL fragments): see below.
+//   - a func(*PageNode) bool predicate for unusual lookups.
+//
 // Type-based lookup is strict: if the same page type is mounted under
 // multiple parents, URLFor returns an error listing every match
 // instead of silently choosing one. Disambiguate with the []any chain
@@ -97,6 +106,16 @@ func URLFor(ctx context.Context, page any, args ...any) (string, error) {
 	pc := pcCtx.Value(ctx)
 	if pc == nil {
 		return "", errors.New("parse context not found in context")
+	}
+
+	// A top-level string is sugar for Ref(string): URLFor(ctx, "Home")
+	// reads cleaner than URLFor(ctx, Ref("Home")), especially at call
+	// sites that can't import the target page (cross-package cycle).
+	// Strings inside the []any composition form remain URL fragments
+	// (e.g. []any{Page{}, "?tab={t}"}); only the top-level position
+	// gets the auto-Ref treatment.
+	if s, ok := page.(string); ok {
+		page = Ref(s)
 	}
 
 	parts, ok := page.([]any)


### PR DESCRIPTION
## Summary

\`URLFor(ctx, \"Parent.Field\")\` is now equivalent to \`URLFor(ctx, Ref(\"Parent.Field\"))\`. Cross-module call sites that can't import the target page (cycle) can drop the \`Ref(...)\` wrapper.

\`\`\`go
url, _ := structpages.URLFor(ctx, \"Admin.Settings\")
url, _ := structpages.URLFor(ctx, \"Notify\", map[string]any{\"q\": q})
\`\`\`

Only the top-level position auto-converts. Strings inside \`[]any{Page{}, \"?tab={t}\"}\` remain URL fragments.

## Design notes

- ID / IDTarget are intentionally **not** changed. \`IDTarget(ctx, \"body\")\` continues to return \`\"body\"\` (documented Rule 11). The asymmetry is: literal URL paths are anti-pattern (the url-attr lint flags them); literal CSS selectors are legitimate.
- Effectively breaking only for callers of \`URLFor(ctx, \"foo\")\` who relied on getting \`\"foo\"\` back as a URL pattern — none in the codebase, examples, or his-project.

## Lint

\`tools/lint\`'s \`ref\` category now validates string args to URLFor the same way it validates \`Ref(...)\` calls. A typo'd or renamed qualified path errors at lint time, not first-call runtime.

## Test Plan

- [ ] \`go test ./...\` — new \`TestURLFor_StringIsRef\` covers single name, qualified path, route literal, with-params, and confirms strings-inside-slice still behave as fragments
- [ ] \`cd tools/lint && go test ./...\` — lint analyzer still green
- [ ] \`cd examples/lint-misuse && go test ./...\` — extended snapshot includes a new \`URLFor(ctx, \"Items.NoSuch\")\` BAD case caught by the analyzer