### PR TITLE
fix(lint): include []any chain fragments in params check

### DIFF
--- a/examples/lint-misuse/lint_test.go
+++ b/examples/lint-misuse/lint_test.go
@@ -33,6 +33,7 @@ pages.go:LINE:COL: [params] URLFor: param "wrong" does not appear in pattern "/i
 pages.go:LINE:COL: [idfor] IDTarget: method expression unmountedPage.Title: receiver type unmountedPage is not mounted as a page
 pages.go:LINE:COL: [ref] Ref "Detail.Index": segment 1 ("Index") not found as child of "Detail"; available:
 pages.go:LINE:COL: [idfor] IDTarget: method "Nope" not found on chain leaf "Detail"; available: Page, Stats
+pages.go:LINE:COL: [params] URLFor: param "wrongTab" does not appear in pattern "/items/{slug}?tab={tab}" (known: slug, tab)
 pages.go:LINE:COL: [ref] Ref "Items.NoSuch": segment 1 ("NoSuch") not found as child of "Items"; available: Detail, Index
 pages.templ:LINE:COL: [url-attr] href value "/login" is a hard-coded internal URL; use structpages.URLFor instead
 pages.templ:LINE:COL: [url-attr] href value "/admin" is a hard-coded internal URL; use structpages.URLFor instead

--- a/examples/lint-misuse/pages.go
+++ b/examples/lint-misuse/pages.go
@@ -127,6 +127,20 @@ func urlSamples(ctx context.Context) {
 	// type matches the leaf, no duplicate descent needed).
 	_, _ = structpages.IDTarget(ctx, []any{itemsRoot{}, itemDetail.Stats})
 
+	// OK: URLFor chain with a trailing query-string fragment whose
+	// {placeholder} is filled by the map. The params check must
+	// inspect the fragment, not just the leaf's FullRoute — slug
+	// comes from the path, preset from the fragment.
+	_, _ = structpages.URLFor(ctx,
+		[]any{itemsRoot{}, itemDetail{}, "?preset={preset}"},
+		map[string]any{"slug": "x", "preset": "weekly"})
+
+	// BAD: chain with a fragment whose placeholder name doesn't
+	// match the map key.
+	_, _ = structpages.URLFor(ctx,
+		[]any{itemsRoot{}, itemDetail{}, "?tab={tab}"},
+		map[string]any{"slug": "x", "wrongTab": "summary"})
+
 	// BAD: ref/string — top-level string is sugar for Ref; the analyzer
 	// validates string args to URLFor the same way it validates Ref(...).
 	_, _ = structpages.URLFor(ctx, "Items.NoSuch")

--- a/tools/lint/params.go
+++ b/tools/lint/params.go
@@ -12,7 +12,12 @@ import (
 // `{name}` and `{name...}` segments. Missing keys are emitted at low
 // confidence because the runtime can pull params from request context
 // — false positives there are easy to silence with the directive.
-func checkParamMap(ctx *checkCtx, node *PageNode, args []ast.Expr) {
+//
+// fragment is the concatenated trailing string fragments of an
+// []any chain (e.g., "?preset={preset}"). Its placeholders are
+// added to the known set so keys filled by the fragment don't
+// trigger false-positive diagnostics.
+func checkParamMap(ctx *checkCtx, node *PageNode, fragment string, args []ast.Expr) {
 	if len(args) == 0 {
 		return
 	}
@@ -24,7 +29,7 @@ func checkParamMap(ctx *checkCtx, node *PageNode, args []ast.Expr) {
 		return
 	}
 
-	pattern := node.FullRoute
+	pattern := node.FullRoute + fragment
 	segments := parsePatternSegments(pattern)
 	if len(segments) == 0 && len(mapLit.Elts) == 0 {
 		return

--- a/tools/lint/urlfor.go
+++ b/tools/lint/urlfor.go
@@ -27,10 +27,24 @@ func checkURLFor(ctx *checkCtx, call *ast.CallExpr) {
 	pageArg := call.Args[1]
 	args := call.Args[2:]
 
-	node := resolvePageArg(ctx, pageArg)
+	node, frag := resolvePageArgAndFragment(ctx, pageArg)
 	if node != nil {
-		checkParamMap(ctx, node, args)
+		checkParamMap(ctx, node, frag, args)
 	}
+}
+
+// resolvePageArgAndFragment is like resolvePageArg but additionally
+// returns the concatenated trailing string fragments of an []any
+// chain. Those fragments contribute placeholders to the URL
+// pattern (e.g., "?preset={preset}" supplies the {preset} key);
+// checkParamMap needs them to avoid false-positive "unknown param"
+// diagnostics.
+func resolvePageArgAndFragment(ctx *checkCtx, expr ast.Expr) (*PageNode, string) {
+	expr = unparen(expr)
+	if comp, ok := asAnySliceLiteral(ctx, expr); ok {
+		return resolveChainLiteralWithFragment(ctx, comp)
+	}
+	return resolvePageArg(ctx, expr), ""
 }
 
 // resolvePageArg classifies the page argument and resolves it to a
@@ -134,6 +148,26 @@ func resolveByType(ctx *checkCtx, pos token.Pos, named *types.Named) *PageNode {
 			named.Obj().Name(), strings.Join(routes, ", "), named.Obj().Name())
 		return nil
 	}
+}
+
+// resolveChainLiteralWithFragment is the chain-form walker that
+// returns the concatenated trailing string fragments alongside the
+// leaf node. Wraps resolveChainLiteral; callers that don't care
+// about the fragment can use resolveChainLiteral directly.
+func resolveChainLiteralWithFragment(ctx *checkCtx, comp *ast.CompositeLit) (*PageNode, string) {
+	node := resolveChainLiteral(ctx, comp)
+	if node == nil {
+		return nil, ""
+	}
+	var frag strings.Builder
+	for _, e := range comp.Elts {
+		s, ok := stringConstantFromPass(ctx, e)
+		if !ok {
+			continue
+		}
+		frag.WriteString(s)
+	}
+	return node, frag.String()
 }
 
 // resolveChainLiteral handles the `[]any{step0, step1, ..., "?fragment"}`


### PR DESCRIPTION
## Summary

URLFor's chain form lets callers append URL fragments after the typed steps:

\`\`\`go
URLFor(ctx, []any{Page{}, \"?preset={preset}\"}, map[string]any{\"preset\": \"weekly\"})
\`\`\`

The lint params analyzer was matching map keys only against \`node.FullRoute\`, ignoring placeholders supplied by the trailing fragments. Real call sites like the above hit a false-positive \"URLFor: param X does not appear in pattern\" and ended up with \`// structpages:lint:ignore params\` directives suppressing legitimate code (his-project's \`modules/receptionist/pages/analytics_urls.go\`).

### Fix

- \`resolvePageArgAndFragment\` returns the concatenated trailing fragments alongside the chain leaf.
- \`checkParamMap\` merges them into the pattern before extracting placeholders.
- Error messages now show the full effective pattern, including the fragment, so the known-keys list matches what callers actually wrote.

### Lint-misuse fixture

Adds two cases:
- \`URLFor(ctx, []any{itemsRoot{}, itemDetail{}, \"?preset={preset}\"}, map[string]any{\"slug\": \"x\", \"preset\": \"weekly\"})\` — silent (was a false positive before).
- \`URLFor(ctx, []any{itemsRoot{}, itemDetail{}, \"?tab={tab}\"}, map[string]any{\"slug\": \"x\", \"wrongTab\": \"summary\"})\` — still flagged; pattern in the error now reads \`/items/{slug}?tab={tab}\` and known keys include \`tab\`.

## Test Plan

- [ ] \`cd tools/lint && go test ./...\` passes
- [ ] \`cd examples/lint-misuse && go test ./...\` passes — snapshot updated
- [ ] After release: \`go install ...@v0.1.7\` and re-run on his-project. The \`// structpages:lint:ignore params\` in \`analytics_urls.go\` becomes unnecessary.