### PR TITLE
test(id): cover cross-package collisions and length degradation

### DIFF
--- a/id_cross_package_test.go
+++ b/id_cross_package_test.go
@@ -1,0 +1,119 @@
+package structpages
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackielii/structpages/internal/idconflicta"
+	"github.com/jackielii/structpages/internal/idconflictb"
+)
+
+// Two different page types, in two different packages, share the same
+// unqualified type name ("Widget") and the same method name ("List").
+// Because the generated ID is derived only from the mount field name
+// (which, for an embedded field, is the unqualified type name) plus the
+// method name, both pages collapse to the SAME id — even though they are
+// distinct components on distinct routes.
+type idConflictSectionA struct {
+	idconflicta.Widget `route:"/a A"`
+}
+
+type idConflictSectionB struct {
+	idconflictb.Widget `route:"/b B"`
+}
+
+type idConflictRoot struct {
+	a idConflictSectionA `route:"/sa SectionA"`
+	b idConflictSectionB `route:"/sb SectionB"`
+}
+
+// TestCrossPackageIDCollision verifies the path-based id scheme gives
+// two distinct same-named types on distinct routes distinct ids.
+func TestCrossPackageIDCollision(t *testing.T) {
+	pc, err := parsePageTree("/", &idConflictRoot{})
+	if err != nil {
+		t.Fatalf("parsePageTree failed: %v", err)
+	}
+	ctx := pcCtx.WithValue(context.Background(), pc)
+
+	idA, err := ID(ctx, idconflicta.Widget.List)
+	if err != nil {
+		t.Fatalf("ID for package-a Widget.List: %v", err)
+	}
+	idB, err := ID(ctx, idconflictb.Widget.List)
+	if err != nil {
+		t.Fatalf("ID for package-b Widget.List: %v", err)
+	}
+
+	if idA != "a-widget-list" {
+		t.Errorf("package a id = %q, want %q", idA, "a-widget-list")
+	}
+	if idB != "b-widget-list" {
+		t.Errorf("package b id = %q, want %q", idB, "b-widget-list")
+	}
+	if idA == idB {
+		t.Fatalf("ids still collide: %q", idA)
+	}
+}
+
+// TestCrossPackageRefAmbiguity verifies a qualified Ref("Widget.List")
+// now reports an ambiguity error (listing both routes) instead of
+// silently resolving to whichever same-named page is reached first.
+func TestCrossPackageRefAmbiguity(t *testing.T) {
+	pc, err := parsePageTree("/", &idConflictRoot{})
+	if err != nil {
+		t.Fatalf("parsePageTree failed: %v", err)
+	}
+	ctx := pcCtx.WithValue(context.Background(), pc)
+
+	id, err := ID(ctx, Ref("Widget.List"))
+	if err == nil {
+		t.Fatalf("expected ambiguity error, got id=%q", id)
+	}
+	for _, want := range []string{"ambiguous", "/sa/a", "/sb/b"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
+// TestCrossPackageStandaloneFunctionID verifies that standalone function
+// components are prefixed by their package name, so two same-named
+// functions in different packages get distinct ids. Standalone functions
+// are not mounted in the tree, so the tree here is irrelevant.
+func TestCrossPackageStandaloneFunctionID(t *testing.T) {
+	pc, err := parsePageTree("/", &idConflictRoot{})
+	if err != nil {
+		t.Fatalf("parsePageTree failed: %v", err)
+	}
+	ctx := pcCtx.WithValue(context.Background(), pc)
+
+	idA, err := ID(ctx, idconflicta.StatsWidget)
+	if err != nil {
+		t.Fatalf("ID for package-a StatsWidget: %v", err)
+	}
+	idB, err := ID(ctx, idconflictb.StatsWidget)
+	if err != nil {
+		t.Fatalf("ID for package-b StatsWidget: %v", err)
+	}
+
+	if idA != "idconflicta-stats-widget" {
+		t.Errorf("package a function id = %q, want %q", idA, "idconflicta-stats-widget")
+	}
+	if idB != "idconflictb-stats-widget" {
+		t.Errorf("package b function id = %q, want %q", idB, "idconflictb-stats-widget")
+	}
+	if idA == idB {
+		t.Fatalf("standalone function ids still collide: %q", idA)
+	}
+
+	// IDTarget adds the "#" selector prefix.
+	sel, err := IDTarget(ctx, idconflicta.StatsWidget)
+	if err != nil {
+		t.Fatalf("IDTarget for package-a StatsWidget: %v", err)
+	}
+	if sel != "#idconflicta-stats-widget" {
+		t.Errorf("package a function selector = %q, want %q", sel, "#idconflicta-stats-widget")
+	}
+}

--- a/id_length_test.go
+++ b/id_length_test.go
@@ -1,0 +1,106 @@
+package structpages
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type degComp struct{}
+
+func (degComp) Box() component { return testComponent{"Box"} }
+
+type degAlpha struct {
+	Item degComp `route:"/item A"`
+}
+
+type degBeta struct {
+	Item degComp `route:"/item B"`
+}
+
+// Two mounts of the same component under different parents share the leaf
+// name "Item", so the compact (leaf-only) id form needs a disambiguating
+// hash suffix.
+type degRoot struct {
+	Alpha degAlpha `route:"/alpha Alpha"`
+	Beta  degBeta  `route:"/beta Beta"`
+}
+
+// TestID_LengthDegradation exercises the full-prefix vs compact-fallback
+// switch driven by maxIDLen, including the stable hash suffix applied to a
+// non-unique leaf name in the compact regime.
+func TestID_LengthDegradation(t *testing.T) {
+	pc, err := parsePageTree("/", &degRoot{})
+	if err != nil {
+		t.Fatalf("parsePageTree: %v", err)
+	}
+	ctx := pcCtx.WithValue(context.Background(), pc)
+
+	// Generous budget → readable full-path form, no hash.
+	pc.maxIDLen = 40
+	alphaFull, err := IDTarget(ctx, []any{degAlpha{}, degComp.Box})
+	if err != nil {
+		t.Fatalf("alpha full: %v", err)
+	}
+	betaFull, err := IDTarget(ctx, []any{degBeta{}, degComp.Box})
+	if err != nil {
+		t.Fatalf("beta full: %v", err)
+	}
+	if alphaFull != "#alpha-item-box" {
+		t.Errorf("alpha full id = %q, want %q", alphaFull, "#alpha-item-box")
+	}
+	if betaFull != "#beta-item-box" {
+		t.Errorf("beta full id = %q, want %q", betaFull, "#beta-item-box")
+	}
+
+	// Tight budget → compact leaf-only form. The leaf "item" is shared, so
+	// each carries a stable 4-hex hash suffix and they stay distinct.
+	pc.maxIDLen = 8
+	alphaC, err := IDTarget(ctx, []any{degAlpha{}, degComp.Box})
+	if err != nil {
+		t.Fatalf("alpha compact: %v", err)
+	}
+	betaC, err := IDTarget(ctx, []any{degBeta{}, degComp.Box})
+	if err != nil {
+		t.Fatalf("beta compact: %v", err)
+	}
+	for _, got := range []string{alphaC, betaC} {
+		base := strings.TrimPrefix(got, "#")
+		if !strings.HasPrefix(base, "item-box-") {
+			t.Errorf("compact id %q does not use the leaf-only form 'item-box-<hash>'", got)
+		}
+		if suffix := strings.TrimPrefix(base, "item-box-"); len(suffix) != 4 {
+			t.Errorf("compact id %q hash suffix = %q, want 4 hex chars", got, suffix)
+		}
+	}
+	if alphaC == betaC {
+		t.Fatalf("compact ids collide despite distinct paths: %q", alphaC)
+	}
+
+	// Stability: recomputing yields the identical hash.
+	again, err := IDTarget(ctx, []any{degAlpha{}, degComp.Box})
+	if err != nil {
+		t.Fatalf("alpha compact again: %v", err)
+	}
+	if again != alphaC {
+		t.Errorf("hash not stable across calls: %q then %q", alphaC, again)
+	}
+}
+
+// TestWithMaxIDLength verifies the option threads through Mount and drives
+// the same full-vs-compact decision via the public API.
+func TestWithMaxIDLength(t *testing.T) {
+	mux := http.NewServeMux()
+	sp, err := Mount(mux, &degRoot{}, "/", "App", WithMaxIDLength(8))
+	if err != nil {
+		t.Fatalf("Mount: %v", err)
+	}
+	got, err := sp.IDTarget([]any{degAlpha{}, degComp.Box})
+	if err != nil {
+		t.Fatalf("IDTarget: %v", err)
+	}
+	if !strings.HasPrefix(strings.TrimPrefix(got, "#"), "item-box-") {
+		t.Errorf("with maxIDLen=8, id = %q, want compact 'item-box-<hash>' form", got)
+	}
+}

--- a/internal/idconflicta/widget.go
+++ b/internal/idconflicta/widget.go
@@ -1,0 +1,25 @@
+// Package idconflicta provides a Widget page type used to demonstrate
+// cross-package ID collisions in tests.
+package idconflicta
+
+import (
+	"context"
+	"io"
+)
+
+type comp struct{ s string }
+
+func (c comp) Render(_ context.Context, w io.Writer) error {
+	_, err := io.WriteString(w, c.s)
+	return err
+}
+
+// Widget is a page type. Note: another package defines a type with the
+// same name "Widget" and the same method name "List".
+type Widget struct{}
+
+func (Widget) List() comp { return comp{s: "a.Widget.List"} }
+
+// StatsWidget is a standalone function component. Another package
+// defines a function with the same name.
+func StatsWidget() comp { return comp{s: "a.StatsWidget"} }

--- a/internal/idconflictb/widget.go
+++ b/internal/idconflictb/widget.go
@@ -1,0 +1,25 @@
+// Package idconflictb provides a Widget page type used to demonstrate
+// cross-package ID collisions in tests.
+package idconflictb
+
+import (
+	"context"
+	"io"
+)
+
+type comp struct{ s string }
+
+func (c comp) Render(_ context.Context, w io.Writer) error {
+	_, err := io.WriteString(w, c.s)
+	return err
+}
+
+// Widget is a page type with the same name as idconflicta.Widget and the
+// same method name "List".
+type Widget struct{}
+
+func (Widget) List() comp { return comp{s: "b.Widget.List"} }
+
+// StatsWidget is a standalone function component with the same name as
+// idconflicta.StatsWidget.
+func StatsWidget() comp { return comp{s: "b.StatsWidget"} }


### PR DESCRIPTION
## Summary

Adds regression coverage for the **path-based element-id scheme** (the `componentID`/`idFromPrefix` work that landed via #23). The implementation is already in `main`; this PR contributes the dedicated tests and the two helper packages they need, which were not part of #23.

Two `internal/` helper packages (`idconflicta`, `idconflictb`) each expose a same-named type (`Widget`) and a same-named standalone function (`StatsWidget`) so the cross-package cases can be exercised faithfully.

## Coverage added

- **`id_cross_package_test.go`**
  - cross-package page ids stay distinct — `a-widget-list` vs `b-widget-list` (the original collision is gone)
  - a qualified `Ref("Widget.List")` now reports an **ambiguity error** listing both routes, instead of silently resolving to the first match
  - standalone function ids are **prefixed by their package name** — `idconflicta-stats-widget` vs `idconflictb-stats-widget`
- **`id_length_test.go`**
  - readable **full-path** form while it fits the budget (`#alpha-item-box` / `#beta-item-box`)
  - **compact** leaf-only fallback past `maxIDLen`, with a stable 4-hex hash suffix on the shared leaf name, kept distinct per path
  - `WithMaxIDLength` threads through `Mount`; hash is stable across repeated calls

## Notes

- Pure test + test-helper additions; no production code changes.
- `go test ./...` passes; `go vet` and `gofmt` clean.