### PR TITLE
lint: add -tags flag to structpages-lint

### DIFF
--- a/tools/lint/buildtags_integration_test.go
+++ b/tools/lint/buildtags_integration_test.go
@@ -1,0 +1,69 @@
+package lint
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/packages"
+)
+
+// urlforDiags loads testdata/buildtags under the given build flags and returns
+// the [urlfor] diagnostics the analyzer reports.
+func urlforDiags(t *testing.T, buildFlags ...string) []string {
+	t.Helper()
+	cfg := &packages.Config{
+		Dir: "testdata/buildtags",
+		Mode: packages.NeedName | packages.NeedTypes | packages.NeedSyntax |
+			packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports |
+			packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedModule,
+		Tests:      true,
+		BuildFlags: buildFlags,
+	}
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if n := packages.PrintErrors(pkgs); n > 0 {
+		t.Fatalf("testdata load errors: %d", n)
+	}
+	tree, _ := BuildTree(pkgs)
+	analyzer := NewAnalyzer(tree)
+	var diags []string
+	for _, pkg := range pkgs {
+		if pkg.TypesInfo == nil || pkg.Types == nil || len(pkg.Syntax) == 0 {
+			continue
+		}
+		pass := &analysis.Pass{
+			Analyzer:  analyzer,
+			Fset:      pkg.Fset,
+			Files:     pkg.Syntax,
+			Pkg:       pkg.Types,
+			TypesInfo: pkg.TypesInfo,
+			Report: func(d analysis.Diagnostic) {
+				if strings.HasPrefix(d.Message, "[urlfor]") {
+					diags = append(diags, d.Message)
+				}
+			},
+			ResultOf: map[*analysis.Analyzer]any{},
+		}
+		if _, err := analyzer.Run(pass); err != nil {
+			t.Fatalf("analyzer run %s: %v", pkg.PkgPath, err)
+		}
+	}
+	return diags
+}
+
+// TestBuildTags_URLForResolvesUnderTag covers the -tags flag: a route gated
+// behind //go:build devtools is unmounted in the default (lean) build, so a
+// URLFor to it from always-compiled code is flagged; loading with
+// -tags=devtools mounts it and the call resolves. The empty devGroup stub must
+// also mount cleanly (no tree error) in the lean case.
+func TestBuildTags_URLForResolvesUnderTag(t *testing.T) {
+	if d := urlforDiags(t); len(d) == 0 {
+		t.Error("without -tags: expected a [urlfor] diagnostic for the unmounted dev page, got none")
+	}
+	if d := urlforDiags(t, "-tags=devtools"); len(d) != 0 {
+		t.Errorf("with -tags=devtools: expected no [urlfor] diagnostics, got %v", d)
+	}
+}

--- a/tools/lint/cmd/structpages-lint/main.go
+++ b/tools/lint/cmd/structpages-lint/main.go
@@ -23,8 +23,11 @@ import (
 )
 
 func main() {
+	tags := flag.String("tags", "", "comma-separated build tags to load packages under "+
+		"(e.g. -tags devtools), so URLFor/ID call sites in code gated behind those tags "+
+		"resolve against the tree that actually mounts them")
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: structpages-lint [packages...]\n")
+		fmt.Fprintf(os.Stderr, "Usage: structpages-lint [-tags tag,tag] [packages...]\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -38,6 +41,9 @@ func main() {
 			packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports |
 			packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedModule,
 		Tests: true,
+	}
+	if *tags != "" {
+		cfg.BuildFlags = []string{"-tags=" + *tags}
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {

--- a/tools/lint/testdata/buildtags/dev.go
+++ b/tools/lint/testdata/buildtags/dev.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"context"
+
+	"github.com/jackielii/structpages"
+)
+
+// devPage's type is always compiled; whether it is MOUNTED depends on the build
+// tag (dev_mounted.go vs dev_stub.go).
+type devPage struct{}
+
+// linkDev is always compiled and URLFors the dev page. With -tags=devtools the
+// page is mounted and this resolves; without it the lint must flag it.
+func linkDev(ctx context.Context) (string, error) {
+	return structpages.URLFor(ctx, devPage{})
+}

--- a/tools/lint/testdata/buildtags/dev_mounted.go
+++ b/tools/lint/testdata/buildtags/dev_mounted.go
@@ -1,0 +1,8 @@
+//go:build devtools
+
+package main
+
+// devGroup mounts the dev-only routes; compiled only with -tags=devtools.
+type devGroup struct {
+	Dev devPage `route:"/_dev Dev"`
+}

--- a/tools/lint/testdata/buildtags/dev_stub.go
+++ b/tools/lint/testdata/buildtags/dev_stub.go
@@ -1,0 +1,7 @@
+//go:build !devtools
+
+package main
+
+// devGroup is empty without the devtools tag — the dev routes are not mounted,
+// so URLFor(devPage{}) cannot resolve unless the lint loads with -tags=devtools.
+type devGroup struct{}

--- a/tools/lint/testdata/buildtags/go.mod
+++ b/tools/lint/testdata/buildtags/go.mod
@@ -1,0 +1,9 @@
+module ex
+
+go 1.24.0
+
+require github.com/jackielii/structpages v0.0.0
+
+require github.com/jackielii/ctxkey v1.0.1 // indirect
+
+replace github.com/jackielii/structpages => ../../../..

--- a/tools/lint/testdata/buildtags/go.sum
+++ b/tools/lint/testdata/buildtags/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/jackielii/ctxkey v1.0.1 h1:CcgbR+fQbrzZJWxI/7Ec4EhzUbmTU1sfI1gV7MAgjIg=
+github.com/jackielii/ctxkey v1.0.1/go.mod h1:fo4HOwrvSnc3n8o5qZ5L+FVcSyQn+d67CCnlEbH24uc=

--- a/tools/lint/testdata/buildtags/main.go
+++ b/tools/lint/testdata/buildtags/main.go
@@ -1,0 +1,22 @@
+// Command ex mounts a base route plus a build-tag-gated dev group: the dev
+// routes are present only under -tags=devtools. Used to test that
+// structpages-lint -tags resolves URLFor call sites against the tagged tree.
+package main
+
+import (
+	"net/http"
+
+	"github.com/jackielii/structpages"
+)
+
+type homePage struct{}
+
+type webPages struct {
+	Home homePage `route:"/{$} Home"`
+	Dev  devGroup `route:"/"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+	structpages.Mount(mux, webPages{}, "/", "App")
+}


### PR DESCRIPTION
## Summary

Adds a `-tags` flag to `structpages-lint` so it can load packages under a given set of build tags. URLFor/ID call sites in always-compiled code that reference routes mounted only behind a build tag (e.g. a dev-tools-only page group) now resolve correctly when the linter is run with the matching tag.

## How

`-tags foo,bar` → `cfg.BuildFlags = []string{"-tags=foo,bar"}` for `packages.Load` (the standard mechanism). Declared before `flag.Parse()`; usage string updated.

## Test

`testdata/buildtags/` models the real case: `devGroup` is tag-gated (`dev_mounted.go` mounts `devPage` under `//go:build devtools`; `dev_stub.go` is an empty stub otherwise), while `linkDev` is always compiled and `URLFor`s the dev page.

- without tags → dev page unmounted → a `[urlfor]` diagnostic is reported
- with `-tags=devtools` → dev page mounted → no diagnostic

The test drives the analyzer through `packages.Config.BuildFlags` (what the CLI sets), validating both states.